### PR TITLE
betterrepeat

### DIFF
--- a/app.html
+++ b/app.html
@@ -112,6 +112,7 @@
                             </ul>
                         </div>
                         <div id="repeat-weekly-unit" class="repeat-subunit" style="display:none" style="display:none">
+                            <t id="repeat-advanced-weekly" style="color:var(--content-normal-accent);font-size: 13px;">Advanced...</t>
                             <div id="repeat-daterow">
                                 <div class="repeat-daterow-weekname">M</div>
                                 <div class="repeat-daterow-weekname">Tu</div>
@@ -123,6 +124,7 @@
                             </div>
                         </div>
                         <div id="repeat-monthly-unit" class="repeat-subunit" style="display:none">
+                            <t id="repeat-advanced-monthly" style="color:var(--content-normal-accent);font-size: 13px;">Advanced...</t>
                             <div id="repeat-monthgrid">
                                 <div class="repeat-monthgrid-day">1</div> <div class="repeat-monthgrid-day">2</div> <div class="repeat-monthgrid-day">3</div> <div class="repeat-monthgrid-day">4</div> <div class="repeat-monthgrid-day">5</div> <div class="repeat-monthgrid-day">6</div> <div class="repeat-monthgrid-day">7</div> <div class="repeat-monthgrid-day">8</div> <div class="repeat-monthgrid-day">9</div> <div class="repeat-monthgrid-day">10</div> <div class="repeat-monthgrid-day">11</div> <div class="repeat-monthgrid-day">12</div> <div class="repeat-monthgrid-day">13</div> <div class="repeat-monthgrid-day">14</div> <div class="repeat-monthgrid-day">15</div> <div class="repeat-monthgrid-day">16</div> <div class="repeat-monthgrid-day">17</div> <div class="repeat-monthgrid-day">18</div> <div class="repeat-monthgrid-day">19</div> <div class="repeat-monthgrid-day">20</div> <div class="repeat-monthgrid-day">21</div> <div class="repeat-monthgrid-day">22</div> <div class="repeat-monthgrid-day">23</div> <div class="repeat-monthgrid-day">24</div> <div class="repeat-monthgrid-day">25</div> <div class="repeat-monthgrid-day">26</div> <div class="repeat-monthgrid-day">27</div> <div class="repeat-monthgrid-day">28</div> <div class="repeat-monthgrid-day">29</div> <div class="repeat-monthgrid-day">30</div> <div class="repeat-monthgrid-day">31</div> <div class="repeat-monthgrid-day">Last</div>
                             </div>

--- a/css/app.css
+++ b/css/app.css
@@ -232,9 +232,9 @@ a {
 }
 
 #repeat-monthly-unit{
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    /*display: flex;*/
+    /*justify-content: center;*/
+    /*align-items: center;*/
 }
 
 #repeat-monthgrid {
@@ -246,6 +246,7 @@ a {
     width: 95%;
     /*background-color: var(--background-feature);*/
     margin: 4px;
+    display: none;
 }
 
 
@@ -255,6 +256,7 @@ a {
     flex-direction: row;
     justify-content: space-between;
     margin-top: 10px;
+    display: none;
 }
 
 #repeat-unit {

--- a/js/app.js
+++ b/js/app.js
@@ -981,7 +981,7 @@ let ui = function() {
                             if (defer) {
                                 let defDistance = due-defer;
                                 due.setDate(due.getDate() + 1);
-                                E.db.modifyTask(uid, taskId, {isComplete: false, due:due, defer:(due-defDistance)});
+                                E.db.modifyTask(uid, taskId, {isComplete: false, due:due, defer:(new Date(due-defDistance))});
                             } else {
                                 due.setDate(due.getDate() + 1);
                                 E.db.modifyTask(uid, taskId, {isComplete: false, due:due});
@@ -992,63 +992,72 @@ let ui = function() {
                                 let rOn = repeat.on;
                                 let current = "";
                                 let defDistance = due-defer;
-                                while (!rOn.includes(current)) {
-                                    due.setDate(due.getDate() + 1);
-                                    let dow = due.getDay();
-                                    switch (dow) {
-                                        case 1:
-                                            current = "M";
-                                            break;
-                                        case 2:
-                                            current = "Tu";
-                                            break;
-                                        case 3:
-                                            current = "W";
-                                            break;
-                                        case 4:
-                                            current = "Th";
-                                            break;
-                                        case 5:
-                                            current = "F";
-                                            break;
-                                        case 6:
-                                            current = "Sa";
-                                            break;
-                                        case 7:
-                                            current = "Su";
-                                            break;
+                                if (rOn) {
+                                    while (!rOn.includes(current)) {
+                                        due.setDate(due.getDate() + 1);
+                                        let dow = due.getDay();
+                                        switch (dow) {
+                                            case 1:
+                                                current = "M";
+                                                break;
+                                            case 2:
+                                                current = "Tu";
+                                                break;
+                                            case 3:
+                                                current = "W";
+                                                break;
+                                            case 4:
+                                                current = "Th";
+                                                break;
+                                            case 5:
+                                                current = "F";
+                                                break;
+                                            case 6:
+                                                current = "Sa";
+                                                break;
+                                            case 7:
+                                                current = "Su";
+                                                break;
+                                        }
                                     }
+                                } else {
+                                    due.setDate(due.getDate()+7);
+                                    defer.setDate(defer.getDate()+7);
                                 }
-                                E.db.modifyTask(uid, taskId, {isComplete: false, due:due, defer:(due-defDistance)});
+                                E.db.modifyTask(uid, taskId, {isComplete: false, due:due, defer:(new Date(due-defDistance))});
                             } else {
                                 let rOn = repeat.on;
-                                let current = "";
-                                while (!rOn.includes(current)) {
-                                    due.setDate(due.getDate() + 1);
-                                    let dow = due.getDay();
-                                    switch (dow) {
-                                        case 1:
-                                            current = "M";
-                                            break;
-                                        case 2:
-                                            current = "Tu";
-                                            break;
-                                        case 3:
-                                            current = "W";
-                                            break;
-                                        case 4:
-                                            current = "Th";
-                                            break;
-                                        case 5:
-                                            current = "F";
-                                            break;
-                                        case 6:
-                                            current = "Sa";
-                                            break;
-                                        case 7:
-                                            current = "Su";
-                                            break;
+                                if (rOn) {
+                                    let current = "";
+                                    while (!rOn.includes(current)) {
+                                        due.setDate(due.getDate() + 1);
+                                        let dow = due.getDay();
+                                        switch (dow) {
+                                            case 1:
+                                                current = "M";
+                                                break;
+                                            case 2:
+                                                current = "Tu";
+                                                break;
+                                            case 3:
+                                                current = "W";
+                                                break;
+                                            case 4:
+                                                current = "Th";
+                                                break;
+                                            case 5:
+                                                current = "F";
+                                                break;
+                                            case 6:
+                                                current = "Sa";
+                                                break;
+                                            case 7:
+                                                current = "Su";
+                                                break;
+                                        }
                                     }
+                                } else {
+                                    due.setDate(due.getDate()+7);
                                 }
                                 E.db.modifyTask(uid, taskId, {isComplete: false, due:due});
                             }
@@ -1058,17 +1067,26 @@ let ui = function() {
                                 let dow = due.getDate();
                                 let oDow = due.getDate();
                                 let defDistance = due-defer;
-                                while ((!rOn.includes(dow.toString()) && !(rOn.includes("Last") && (new Date(due.getFullYear(), due.getMonth(), due.getDate()).getDate() === new Date(due.getFullYear(), due.getMonth()+1, 0).getDate()))) || (oDow === dow)) {
-                                    due.setDate(due.getDate() + 1);
-                                    dow = due.getDate();
+                                if (rOn) {
+                                    while ((!rOn.includes(dow.toString()) && !(rOn.includes("Last") && (new Date(due.getFullYear(), due.getMonth(), due.getDate()).getDate() === new Date(due.getFullYear(), due.getMonth()+1, 0).getDate()))) || (oDow === dow)) {
+                                        due.setDate(due.getDate() + 1);
+                                        dow = due.getDate();
+                                    }
+                                } else {
+                                    due.setMonth(due.getMonth()+1);
                                 }
+                                E.db.modifyTask(uid, taskId, {isComplete: false, due:due, defer:(new Date(due-defDistance))});
                             } else {
                                 let rOn = repeat.on;
-                                let dow = due.getDate();
-                                let oDow = due.getDate();
-                                while ((!rOn.includes(dow.toString()) && !(rOn.includes("Last") && (new Date(due.getFullYear(), due.getMonth(), due.getDate()).getDate() === new Date(due.getFullYear(), due.getMonth()+1, 0).getDate()))) || (oDow === dow)) {
-                                    due.setDate(due.getDate() + 1);
-                                    dow = due.getDate();
+                                if (rOn) {
+                                    let dow = due.getDate();
+                                    let oDow = due.getDate();
+                                    while ((!rOn.includes(dow.toString()) && !(rOn.includes("Last") && (new Date(due.getFullYear(), due.getMonth(), due.getDate()).getDate() === new Date(due.getFullYear(), due.getMonth()+1, 0).getDate()))) || (oDow === dow)) {
+                                        due.setDate(due.getDate() + 1);
+                                        dow = due.getDate();
+                                    }
+                                } else {
+                                    due.setMonth(due.getMonth()+1);
                                 }
                                 E.db.modifyTask(uid, taskId, {isComplete: false, due:due});
                             }
@@ -1076,7 +1094,7 @@ let ui = function() {
                             if (defer) {
                                 let defDistance = due-defer;
                                 due.setFullYear(due.getFullYear() + 1);
-                                E.db.modifyTask(uid, taskId, {isComplete: false, due:due, defer:(due-defDistance)});
+                                E.db.modifyTask(uid, taskId, {isComplete: false, due:due, defer:(new Date(due-defDistance))});
                             } else {
                                 due.setFullYear(due.getFullYear() + 1);
                                 E.db.modifyTask(uid, taskId, {isComplete: false, due:due});

--- a/js/app.js
+++ b/js/app.js
@@ -344,6 +344,8 @@ let ui = function() {
         let tid;
         let repeatWeekDays = [];
         let repeatMonthDays = [];
+        let advancedMonthMode = false;
+        let advancedWeekMode = false;
 
         // Setup repeat things!
         $("#repeat-back").on("click", function(e) {
@@ -361,6 +363,48 @@ let ui = function() {
             $("#"+activeMenu).addClass("menuitem-selected");
             let repeatWeekDays = [];
             let repeatMonthDays = [];
+        });
+
+        $("#repeat-advanced-monthly").on("click", function(e) {
+            if (advancedMonthMode) {
+                $(this).html("Advanced...");
+                $("#repeat-monthgrid").fadeOut();
+                E.db.modifyTask(uid, tid, {repeat: {rule: "monthly"}});
+                $("#repeat-monthgrid").children().each(function(e) {
+                    $(this).css({"background-color": interfaceUtil.gtc("--background")});
+                });
+            } else {
+                $(this).html("Back to Basic...");
+                $("#repeat-monthgrid").fadeIn({
+                  start: function () {
+                    $(this).css({
+                      display: "grid"
+                    })
+                  }
+                });
+            }
+            advancedMonthMode = !advancedMonthMode;
+        });
+
+        $("#repeat-advanced-weekly").on("click", function(e) {
+            if (advancedWeekMode) {
+                $(this).html("Advanced...");
+                $("#repeat-daterow").fadeOut();
+                E.db.modifyTask(uid, tid, {repeat: {rule: "weekly"}});
+                $("#repeat-daterow").children().each(function(e) {
+                    $(this).css({"background-color": interfaceUtil.gtc("--background-feature")});
+                });
+            } else {
+                $(this).html("Back to Basic...");
+                $("#repeat-daterow").fadeIn({
+                  start: function () {
+                    $(this).css({
+                      display: "flex"
+                    })
+                  }
+                });
+            }
+            advancedWeekMode = !advancedWeekMode;
         });
 
 
@@ -402,6 +446,7 @@ let ui = function() {
             $("#repeat-toggle-group").slideUp();
             $("#repeat-type").html("every week.");
             $("#repeat-type").fadeIn();
+            E.db.modifyTask(uid, tid, {repeat: {rule: "weekly"}});
         });
 
         $("#repeat-permonth").on("click", function(e) {
@@ -409,6 +454,7 @@ let ui = function() {
             $("#repeat-toggle-group").slideUp();
             $("#repeat-type").html("every month.");
             $("#repeat-type").fadeIn();
+            E.db.modifyTask(uid, tid, {repeat: {rule: "monthly"}});
         });
 
         $("#repeat-peryear").on("click", function(e) {
@@ -460,23 +506,49 @@ let ui = function() {
                     $("#repeat-type").html("every day.");
                     $("#repeat-type").show();
                 } else if (ti.repeat.rule === "weekly") {
-                    $("#repeat-daterow").children().each(function(e) {
-                        if (ti.repeat.on.includes($(this).html())) {
-                            $(this).animate({"background-color": interfaceUtil.gtc("--decorative-light")});
-                        }
-                    });
-                    repeatWeekDays = ti.repeat.on;
+                    if (ti.repeat.on) {
+                        $("#repeat-daterow").children().each(function(e) {
+                            if (ti.repeat.on.includes($(this).html())) {
+                                $(this).animate({"background-color": interfaceUtil.gtc("--decorative-light")});
+                            }
+                        });
+                        repeatWeekDays = ti.repeat.on;
+                        $("#repeat-advanced-weekly").html("Back to Basic...");
+                        $("#repeat-daterow").fadeIn({
+                          start: function () {
+                            $(this).css({
+                              display: "flex"
+                            })
+                          }
+                        });
+                        advancedWeekMode = true;
+                    } else {
+                        advancedWeekMode = false;
+                    }
                     $("#repeat-weekly-unit").show();
                     $("#repeat-toggle-group").hide();
                     $("#repeat-type").html("every week.");
                     $("#repeat-type").show();
                 } else if (ti.repeat.rule === "monthly") {
-                    $("#repeat-monthgrid").children().each(function(e) {
-                        if (ti.repeat.on.includes($(this).html())) {
-                            $(this).animate({"background-color": interfaceUtil.gtc("--background-feature")});
-                        }
-                    });
-                    repeatMonthDays = ti.repeat.on;
+                    if (ti.repeat.on) {
+                        $("#repeat-monthgrid").children().each(function(e) {
+                            if (ti.repeat.on.includes($(this).html())) {
+                                $(this).animate({"background-color": interfaceUtil.gtc("--background-feature")});
+                            }
+                        });
+                        repeatMonthDays = ti.repeat.on;
+                        $("#repeat-advanced-monthly").html("Back to Basic...");
+                        $("#repeat-monthgrid").fadeIn({
+                          start: function () {
+                            $(this).css({
+                              display: "grid"
+                            })
+                          }
+                        });
+                        advancedMonthMode = true;
+                    } else {
+                        advancedMonthMode = false;
+                    }
                     $("#repeat-monthly-unit").show();
                     $("#repeat-toggle-group").hide();
                     $("#repeat-type").html("every month.");


### PR DESCRIPTION
Advanced features shoulden't be default, right? Then why did yours truly think it was a good idea to enable custom repeats on weeks/months? I don't know... Who should I ask?

Anyways, now there's a nifty little button that says "Advanced" that opens the dategrid. Otherwise, repeats are now set automatically as long as the dropdown is selected (Month => +1month from current due, week => +7days from current due.)

Fun, right?