### PR TITLE
Dev daterow

### DIFF
--- a/about.html
+++ b/about.html
@@ -61,7 +61,7 @@
         <div id="center">
             <h1 style="margin:0; font-size: 24px; padding-bottom: 6px"><t style="font-weight: 300;padding-right: 3px;">#!/Shabang</t> <b style="color:#434d5f;">Condution</b></h1>
             <t style="font-size: 15px; font-weight: 600; padding-right: 10px;">Tasks? Done. That was easy.</t>
-            <t style="font-size: 12px; font-weight: 300"><b>Bontehu!</b> beta-v0.1.3_build2</t>
+            <t style="font-size: 12px; font-weight: 300"><b>IWTBYPP!</b> beta-v0.2.0_build0</t>
             <br />
             <br />
             <br />

--- a/app.html
+++ b/app.html
@@ -155,17 +155,67 @@
                     <div style="padding: 0 0 7px 0">
                         <hr class="perspective-divider"/>
                         <div id="upcoming-header"><t id="greeting"></t><t id="greeting-name"></t>&middot;<t id="greeting-date"></t></div>
-                        <hr class="perspective-divider"/>
+                        <!--<hr class="perspective-divider"/>-->
                     </div>
                     <div id="upcoming-daterow">
-                        <div class="upcoming-daterow-item">Bo!</div>
-                        <div class="upcoming-daterow-item">Bo!</div>
-                        <div class="upcoming-daterow-item">Bo!</div>
-                        <div class="upcoming-daterow-item">Bo!</div>
-                        <div class="upcoming-daterow-item">Bo!</div>
-                        <div class="upcoming-daterow-item">Bo!</div>
-                        <div class="upcoming-daterow-item">Bo!</div>
+                        <div id="upcoming-daterow-0" class="upcoming-daterow-item upcoming-daterow-active">
+                            <div class="upcoming-daterow-t" id="upcoming-daterow-t0">4</div>
+                            <div style="transform: translateY(-2px);">
+                                <div class="upcoming-daterow-d" id="upcoming-daterow-d0">24</div>
+                                <div class="upcoming-daterow-w" id="upcoming-daterow-w0">Wed</div>
+                            </div>
+                        </div>
+                        <div id="upcoming-daterow-1" class="upcoming-daterow-item">
+                            <div class="upcoming-daterow-t" id="upcoming-daterow-t1">2</div>
+                            <div style="transform: translateY(-2px);">
+                                <div class="upcoming-daterow-d" id="upcoming-daterow-d1">25</div>
+                                <div class="upcoming-daterow-w" id="upcoming-daterow-w1">Thu</div>
+                            </div>
+                        </div>
+                        <div id="upcoming-daterow-2" class="upcoming-daterow-item">
+                            <div class="upcoming-daterow-t" id="upcoming-daterow-t2">2</div>
+                            <div style="transform: translateY(-2px);">
+                                <div class="upcoming-daterow-d" id="upcoming-daterow-d2">26</div>
+                                <div class="upcoming-daterow-w" id="upcoming-daterow-w2">Fri</div>
+                            </div>
+                        </div>
+                        <div id="upcoming-daterow-3" class="upcoming-daterow-item">
+                            <div class="upcoming-daterow-t" id="upcoming-daterow-t3">8</div>
+                            <div style="transform: translateY(-2px);">
+                                <div class="upcoming-daterow-d" id="upcoming-daterow-d3">27</div>
+                                <div class="upcoming-daterow-w" id="upcoming-daterow-w3">Sat</div>
+                            </div>
+                        </div>
+                        <div id="upcoming-daterow-4" class="upcoming-daterow-item">
+                            <div class="upcoming-daterow-t" id="upcoming-daterow-t4">0</div>
+                            <div style="transform: translateY(-2px);">
+                                <div class="upcoming-daterow-d" id="upcoming-daterow-d4">28</div>
+                                <div class="upcoming-daterow-w" id="upcoming-daterow-w4">Sun</div>
+                            </div>
+                        </div>
+                        <div id="upcoming-daterow-5" class="upcoming-daterow-item">
+                            <div class="upcoming-daterow-t" id="upcoming-daterow-t5">1</div>
+                            <div style="transform: translateY(-2px);">
+                                <div class="upcoming-daterow-d" id="upcoming-daterow-d5">29</div>
+                                <div class="upcoming-daterow-w" id="upcoming-daterow-w5">Mon</div>
+                            </div>
+                        </div>
+                        <div id="upcoming-daterow-6" class="upcoming-daterow-item">
+                            <div class="upcoming-daterow-t" id="upcoming-daterow-t6">0</div>
+                            <div style="transform: translateY(-2px);">
+                                <div class="upcoming-daterow-d" id="upcoming-daterow-d6">30</div>
+                                <div class="upcoming-daterow-w" id="upcoming-daterow-w6">Tues</div>
+                            </div>
+                        </div>
+                        <div id="upcoming-daterow-7" class="upcoming-daterow-item">
+                            <div class="upcoming-daterow-t" id="upcoming-daterow-t7">4</div>
+                            <div style="transform: translateY(-2px);">
+                                <div class="upcoming-daterow-d" id="upcoming-daterow-d3">1</div>
+                                <div class="upcoming-daterow-w" id="upcoming-daterow-w3">Wed</div>
+                            </div>
+                        </div>
                     </div>
+                    <hr class="perspective-divider"/>
                     <div id="blankimage-today" class="blankimage-content">
                         <img class="blankimage"></img>
                         <div class="blankimage-alt">Wow... How empty. <b style="font-weight: 200">(Quick)Add a task?</b></div>

--- a/app.html
+++ b/app.html
@@ -159,59 +159,59 @@
                     </div>
                     <div id="upcoming-daterow">
                         <div id="upcoming-daterow-0" class="upcoming-daterow-item upcoming-daterow-active">
-                            <div class="upcoming-daterow-t" id="upcoming-daterow-t0">4</div>
+                            <div class="upcoming-daterow-t" id="upcoming-daterow-t0"></div>
                             <div style="transform: translateY(-2px);">
-                                <div class="upcoming-daterow-d" id="upcoming-daterow-d0">24</div>
-                                <div class="upcoming-daterow-w" id="upcoming-daterow-w0">Wed</div>
+                                <div class="upcoming-daterow-d" id="upcoming-daterow-d0"></div>
+                                <div class="upcoming-daterow-w" id="upcoming-daterow-w0"></div>
                             </div>
                         </div>
                         <div id="upcoming-daterow-1" class="upcoming-daterow-item">
-                            <div class="upcoming-daterow-t" id="upcoming-daterow-t1">2</div>
+                            <div class="upcoming-daterow-t" id="upcoming-daterow-t1"></div>
                             <div style="transform: translateY(-2px);">
-                                <div class="upcoming-daterow-d" id="upcoming-daterow-d1">25</div>
-                                <div class="upcoming-daterow-w" id="upcoming-daterow-w1">Thu</div>
+                                <div class="upcoming-daterow-d" id="upcoming-daterow-d1"></div>
+                                <div class="upcoming-daterow-w" id="upcoming-daterow-w1"></div>
                             </div>
                         </div>
                         <div id="upcoming-daterow-2" class="upcoming-daterow-item">
-                            <div class="upcoming-daterow-t" id="upcoming-daterow-t2">2</div>
+                            <div class="upcoming-daterow-t" id="upcoming-daterow-t2"></div>
                             <div style="transform: translateY(-2px);">
-                                <div class="upcoming-daterow-d" id="upcoming-daterow-d2">26</div>
-                                <div class="upcoming-daterow-w" id="upcoming-daterow-w2">Fri</div>
+                                <div class="upcoming-daterow-d" id="upcoming-daterow-d2"></div>
+                                <div class="upcoming-daterow-w" id="upcoming-daterow-w2"></div>
                             </div>
                         </div>
                         <div id="upcoming-daterow-3" class="upcoming-daterow-item">
-                            <div class="upcoming-daterow-t" id="upcoming-daterow-t3">8</div>
+                            <div class="upcoming-daterow-t" id="upcoming-daterow-t3"></div>
                             <div style="transform: translateY(-2px);">
-                                <div class="upcoming-daterow-d" id="upcoming-daterow-d3">27</div>
-                                <div class="upcoming-daterow-w" id="upcoming-daterow-w3">Sat</div>
+                                <div class="upcoming-daterow-d" id="upcoming-daterow-d3"></div>
+                                <div class="upcoming-daterow-w" id="upcoming-daterow-w3"></div>
                             </div>
                         </div>
                         <div id="upcoming-daterow-4" class="upcoming-daterow-item">
-                            <div class="upcoming-daterow-t" id="upcoming-daterow-t4">0</div>
+                            <div class="upcoming-daterow-t" id="upcoming-daterow-t4"></div>
                             <div style="transform: translateY(-2px);">
-                                <div class="upcoming-daterow-d" id="upcoming-daterow-d4">28</div>
-                                <div class="upcoming-daterow-w" id="upcoming-daterow-w4">Sun</div>
+                                <div class="upcoming-daterow-d" id="upcoming-daterow-d4"></div>
+                                <div class="upcoming-daterow-w" id="upcoming-daterow-w4"></div>
                             </div>
                         </div>
                         <div id="upcoming-daterow-5" class="upcoming-daterow-item">
-                            <div class="upcoming-daterow-t" id="upcoming-daterow-t5">1</div>
+                            <div class="upcoming-daterow-t" id="upcoming-daterow-t5"></div>
                             <div style="transform: translateY(-2px);">
-                                <div class="upcoming-daterow-d" id="upcoming-daterow-d5">29</div>
-                                <div class="upcoming-daterow-w" id="upcoming-daterow-w5">Mon</div>
+                                <div class="upcoming-daterow-d" id="upcoming-daterow-d5"></div>
+                                <div class="upcoming-daterow-w" id="upcoming-daterow-w5"></div>
                             </div>
                         </div>
                         <div id="upcoming-daterow-6" class="upcoming-daterow-item">
-                            <div class="upcoming-daterow-t" id="upcoming-daterow-t6">0</div>
+                            <div class="upcoming-daterow-t" id="upcoming-daterow-t6"></div>
                             <div style="transform: translateY(-2px);">
-                                <div class="upcoming-daterow-d" id="upcoming-daterow-d6">30</div>
-                                <div class="upcoming-daterow-w" id="upcoming-daterow-w6">Tues</div>
+                                <div class="upcoming-daterow-d" id="upcoming-daterow-d6"></div>
+                                <div class="upcoming-daterow-w" id="upcoming-daterow-w6"></div>
                             </div>
                         </div>
                         <div id="upcoming-daterow-7" class="upcoming-daterow-item">
-                            <div class="upcoming-daterow-t" id="upcoming-daterow-t7">4</div>
+                            <div class="upcoming-daterow-t" id="upcoming-daterow-t7"></div>
                             <div style="transform: translateY(-2px);">
-                                <div class="upcoming-daterow-d" id="upcoming-daterow-d3">1</div>
-                                <div class="upcoming-daterow-w" id="upcoming-daterow-w3">Wed</div>
+                                <div class="upcoming-daterow-d" id="upcoming-daterow-d7"></div>
+                                <div class="upcoming-daterow-w" id="upcoming-daterow-w7"></div>
                             </div>
                         </div>
                     </div>

--- a/app.html
+++ b/app.html
@@ -165,49 +165,49 @@
                                 <div class="upcoming-daterow-w" id="upcoming-daterow-w0"></div>
                             </div>
                         </div>
-                        <div id="upcoming-daterow-1" class="upcoming-daterow-item">
+                        <div id="upcoming-daterow-1" class="upcoming-daterow-item upcoming-daterow-normal">
                             <div class="upcoming-daterow-t" id="upcoming-daterow-t1"></div>
                             <div style="transform: translateY(-2px);">
                                 <div class="upcoming-daterow-d" id="upcoming-daterow-d1"></div>
                                 <div class="upcoming-daterow-w" id="upcoming-daterow-w1"></div>
                             </div>
                         </div>
-                        <div id="upcoming-daterow-2" class="upcoming-daterow-item">
+                        <div id="upcoming-daterow-2" class="upcoming-daterow-item upcoming-daterow-normal">
                             <div class="upcoming-daterow-t" id="upcoming-daterow-t2"></div>
                             <div style="transform: translateY(-2px);">
                                 <div class="upcoming-daterow-d" id="upcoming-daterow-d2"></div>
                                 <div class="upcoming-daterow-w" id="upcoming-daterow-w2"></div>
                             </div>
                         </div>
-                        <div id="upcoming-daterow-3" class="upcoming-daterow-item">
+                        <div id="upcoming-daterow-3" class="upcoming-daterow-item upcoming-daterow-normal">
                             <div class="upcoming-daterow-t" id="upcoming-daterow-t3"></div>
                             <div style="transform: translateY(-2px);">
                                 <div class="upcoming-daterow-d" id="upcoming-daterow-d3"></div>
                                 <div class="upcoming-daterow-w" id="upcoming-daterow-w3"></div>
                             </div>
                         </div>
-                        <div id="upcoming-daterow-4" class="upcoming-daterow-item">
+                        <div id="upcoming-daterow-4" class="upcoming-daterow-item upcoming-daterow-normal">
                             <div class="upcoming-daterow-t" id="upcoming-daterow-t4"></div>
                             <div style="transform: translateY(-2px);">
                                 <div class="upcoming-daterow-d" id="upcoming-daterow-d4"></div>
                                 <div class="upcoming-daterow-w" id="upcoming-daterow-w4"></div>
                             </div>
                         </div>
-                        <div id="upcoming-daterow-5" class="upcoming-daterow-item">
+                        <div id="upcoming-daterow-5" class="upcoming-daterow-item upcoming-daterow-normal">
                             <div class="upcoming-daterow-t" id="upcoming-daterow-t5"></div>
                             <div style="transform: translateY(-2px);">
                                 <div class="upcoming-daterow-d" id="upcoming-daterow-d5"></div>
                                 <div class="upcoming-daterow-w" id="upcoming-daterow-w5"></div>
                             </div>
                         </div>
-                        <div id="upcoming-daterow-6" class="upcoming-daterow-item">
+                        <div id="upcoming-daterow-6" class="upcoming-daterow-item upcoming-daterow-normal">
                             <div class="upcoming-daterow-t" id="upcoming-daterow-t6"></div>
                             <div style="transform: translateY(-2px);">
                                 <div class="upcoming-daterow-d" id="upcoming-daterow-d6"></div>
                                 <div class="upcoming-daterow-w" id="upcoming-daterow-w6"></div>
                             </div>
                         </div>
-                        <div id="upcoming-daterow-7" class="upcoming-daterow-item">
+                        <div id="upcoming-daterow-7" class="upcoming-daterow-item upcoming-daterow-normal">
                             <div class="upcoming-daterow-t" id="upcoming-daterow-t7"></div>
                             <div style="transform: translateY(-2px);">
                                 <div class="upcoming-daterow-d" id="upcoming-daterow-d7"></div>
@@ -216,16 +216,12 @@
                         </div>
                     </div>
                     <hr class="perspective-divider"/>
-                    <div id="blankimage-today" class="blankimage-content">
-                        <img class="blankimage"></img>
-                        <div class="blankimage-alt">Wow... How empty. <b style="font-weight: 200">(Quick)Add a task?</b></div>
-                    </div>
                     <div id="inbox-subhead" class="perspective-subhead">
                         Unsorted <div id="unsorted-badge" class="badge" style="transform: translate(3px, -2px)"></div>
                     </div>
                     <div id="inbox" class="upcoming-section"> </div>
                     <div id="ds-subhead" class="perspective-subhead">
-                        Due Soon <div id="duesoon-badge" class="badge" style="transform: translate(3px, -2px)"></div> <div style="font-weight: 600; display: inline-block; padding-left: 10px; font-size: 10px; transform: translateY(-1px);">@</div> <div id="duesoon-ondate">Today, June 24</div>
+                        <t id="ds-text">Due Soon</t> <div id="duesoon-badge" class="badge" style="transform: translate(3px, -2px)">0</div> <div id="ds-daterowfield" style="display:none; transform: translateY(-1px)"><div style="font-weight: 600; display: inline-block; font-size: 10px;">@</div> <div id="duesoon-ondate"></div> </div>
                     </div>
                     <div id="due-soon" class="upcoming-section"> </div>
                 </div>

--- a/app.html
+++ b/app.html
@@ -66,7 +66,7 @@
             </t>
             <div id="loading-anim"></div>
             <t id="loading-msg-sub"><b style="font-weight: 800 !important">Condution</b> is Loading...</t>
-            <t id="loading-bottom">&#169;2019-2020 Shabang Systems, LLC and the Condution Project Contributors. Licensed and Distributed under GPL-v3.0. beta-v0.1.3_build2.</t>
+            <t id="loading-bottom">&#169;2019-2020 Shabang Systems, LLC and the Condution Project Contributors. Licensed and Distributed under GPL-v3.0. beta-v0.2.0_build0.</t>
         </div>
         <div id="content-wrapper" style="display:none">
             <div id="overlay">

--- a/app.html
+++ b/app.html
@@ -157,6 +157,15 @@
                         <div id="upcoming-header"><t id="greeting"></t><t id="greeting-name"></t>&middot;<t id="greeting-date"></t></div>
                         <hr class="perspective-divider"/>
                     </div>
+                    <div id="upcoming-daterow">
+                        <div class="upcoming-daterow-item">Bo!</div>
+                        <div class="upcoming-daterow-item">Bo!</div>
+                        <div class="upcoming-daterow-item">Bo!</div>
+                        <div class="upcoming-daterow-item">Bo!</div>
+                        <div class="upcoming-daterow-item">Bo!</div>
+                        <div class="upcoming-daterow-item">Bo!</div>
+                        <div class="upcoming-daterow-item">Bo!</div>
+                    </div>
                     <div id="blankimage-today" class="blankimage-content">
                         <img class="blankimage"></img>
                         <div class="blankimage-alt">Wow... How empty. <b style="font-weight: 200">(Quick)Add a task?</b></div>
@@ -166,7 +175,7 @@
                     </div>
                     <div id="inbox" class="upcoming-section"> </div>
                     <div id="ds-subhead" class="perspective-subhead">
-                        Due Soon <div id="duesoon-badge" class="badge" style="transform: translate(3px, -2px)"></div>
+                        Due Soon <div id="duesoon-badge" class="badge" style="transform: translate(3px, -2px)"></div> <div style="font-weight: 600; display: inline-block; padding-left: 10px; font-size: 10px; transform: translateY(-1px);">@</div> <div id="duesoon-ondate">Today, June 24</div>
                     </div>
                     <div id="due-soon" class="upcoming-section"> </div>
                 </div>

--- a/css/app.css
+++ b/css/app.css
@@ -45,8 +45,46 @@ a {
 #upcoming-daterow {
     display: flex;
     flex-direction: row;
-    justify-content: space-evenly;
-    height: 30px;
+    /*justify-content: center;*/
+    height: 45px;
+    margin-bottom: 10px;
+    margin-top: 6px;
+}
+
+.upcoming-daterow-item {
+    background: var(--background-feature);
+    color: var(--content-normal-alt);
+    font-size: 15px;
+    display: flex;
+    justify-content: flex-start;
+    flex-direction: column;
+    align-items: center;
+    width: 60px;
+    margin: 2px 2px;
+    border-radius: 2px;
+}
+
+.upcoming-daterow-t {
+    font-weight: 700;
+    color: var(--content-normal-alt);
+    transform: translateY(4px);
+}
+
+.upcoming-daterow-w {
+    font-weight: 600;
+    font-size: 10px;
+    display: inline-block;
+}
+
+.upcoming-daterow-d {
+    font-weight: 300;
+    font-size: 10px;
+    display: inline-block;
+}
+
+
+.upcoming-daterow-active {
+    background: var(--decorative-light);
 }
 
 #perspective-edit-name {
@@ -126,7 +164,7 @@ a {
 .perspective-subhead{
     color: var(--content-normal-alt);
     font-weight: 500;
-    padding-top: 2px;
+    padding-top: 4px;
     padding-bottom: 3px;
     font-size: 15px;
 }

--- a/css/app.css
+++ b/css/app.css
@@ -62,6 +62,11 @@ a {
     width: 60px;
     margin: 2px 2px;
     border-radius: 2px;
+    transition: 0.5s all;
+}
+
+.upcoming-daterow-item:hover {
+    background: var(--content-normal);
 }
 
 .upcoming-daterow-t {

--- a/css/app.css
+++ b/css/app.css
@@ -34,6 +34,21 @@ a {
     padding-bottom:9px;
 }
 
+#duesoon-ondate {
+    font-weight: 300;
+    display: inline-block;
+    /*padding-left: 1px;*/
+    font-size: 12px;
+    transform: translateY(-1px);
+}
+
+#upcoming-daterow {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+    height: 30px;
+}
+
 #perspective-edit-name {
     color: var(--content-normal-accent);
     padding-left: 4px;

--- a/css/app.css
+++ b/css/app.css
@@ -37,9 +37,7 @@ a {
 #duesoon-ondate {
     font-weight: 300;
     display: inline-block;
-    /*padding-left: 1px;*/
     font-size: 12px;
-    transform: translateY(-1px);
 }
 
 #upcoming-daterow {
@@ -65,7 +63,7 @@ a {
     transition: 0.5s all;
 }
 
-.upcoming-daterow-item:hover {
+.upcoming-daterow-normal:hover {
     background: var(--content-normal);
 }
 

--- a/js/app.js
+++ b/js/app.js
@@ -128,7 +128,7 @@ let ui = function() {
     let greeting = greetings[Math.floor(Math.random() * greetings.length)];
 
     // generic data containers used by refresh and others
-    let pPandT, possibleProjects, possibleTags, possibleProjectsRev, possibleTagsRev;
+    let pPandT, possibleProjects, possibleTags, possibleProjectsRev, possibleTagsRev, nextSevenDSes;
     let possiblePerspectives;
     let inboxandDS;
     let avalibility;
@@ -138,6 +138,7 @@ let ui = function() {
     let pageIndex = {
         currentView: "upcoming-page",
         projectDir: [],
+        dateSelected: 0,
         pageContentID: undefined,
         pageLocks: [],
         dateLoaders: {},
@@ -156,6 +157,7 @@ let ui = function() {
         possiblePerspectives = await E.db.getPerspectives(uid);
         avalibility = await E.db.getItemAvailability(uid);
         inboxandDS = await E.db.getInboxandDS(uid, avalibility);
+        nextSevenDSes = await E.db.getDSRow(uid, avalibility);
         projectDB = await (async function() {
             let pdb = [];
             let topLevels = (await E.db.getTopLevelProjects(uid))[0];
@@ -1432,7 +1434,14 @@ let ui = function() {
             $("#greeting-date").html((new Date().toLocaleDateString("en-GB", { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })));
             $("#greeting").html(greeting);
             $("#greeting-name").html(displayName);
-
+            //nextSevenDSes
+            let d = new Date();
+            for (let i = 0; i <= 7; i++) {
+                $("#upcoming-daterow-t"+i).html(nextSevenDSes[i].length);
+                $("#upcoming-daterow-d"+i).html(d.getDate());
+                $("#upcoming-daterow-w"+i).html(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][d.getDay()]);
+                d.setDate(d.getDate()+1);
+            }
             $("#blankimage-today").css("opacity", "0.0");
             $("#blankimage-today").css("display", (inboxandDS[0].length + inboxandDS[1].length == 0) ? "flex" : "none")
             $("#blankimage-today").animate({"opacity": "0.2"});
@@ -1440,7 +1449,7 @@ let ui = function() {
                 // load inbox tasks
                 inboxandDS[0].map(task => taskManager.generateTaskInterface("inbox", task)),
                 // load due soon tasks
-                inboxandDS[1].map(task => taskManager.generateTaskInterface("due-soon", task))
+                (pageIndex.dateSelected == 0 ? inboxandDS[1] : nextSevenDSes[pageIndex.dateSelected]).map(task => taskManager.generateTaskInterface("due-soon", task))
             ).then(function() {
                 // update upcoming view headers
                 if (inboxandDS[0].length === 0) {
@@ -1594,6 +1603,16 @@ let ui = function() {
             pageIndex.projectDir.push(activeMenu);
             loadView("project-page", activeMenu.split("-")[1]);
         }
+    });
+    
+    $(document).on('click', '.upcoming-daterow-item', function(e) {
+        $("#upcoming-daterow").children().each(function() {
+            $(this).removeClass("upcoming-daterow-active");
+        });
+        let original = $(this);
+        original.addClass("upcoming-daterow-active");
+        pageIndex.dateSelected = original.attr("id").split("-")[2]
+        loadView("upcoming-page");
     });
 
     $(document).on('click', '.today', function(e) {

--- a/js/app.js
+++ b/js/app.js
@@ -607,10 +607,7 @@ let ui = function() {
             } else if (activeTaskDeDsed) {
                 let hTask = activeTask;
                 dsC = inboxandDS[1].length;
-                if (dsC === 0) {
-                    $("#ds-subhead").slideUp(300);
-                    $("#due-soon").slideUp(300);
-                } else {
+                if (dsC !== 0) {
                     $("#duesoon-badge").html(''+dsC);
                     if (activeMenu==="today" && $($('#task-' + hTask).parent()).attr('id') !== "inbox") {
                         $('#task-'+hTask).slideUp(200);
@@ -1111,7 +1108,7 @@ let ui = function() {
 
                         }
                     }
-                    reloadPage();
+                    reloadPage(true);
                 }
             });
 
@@ -1442,9 +1439,6 @@ let ui = function() {
                 $("#upcoming-daterow-w"+i).html(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][d.getDay()]);
                 d.setDate(d.getDate()+1);
             }
-            $("#blankimage-today").css("opacity", "0.0");
-            $("#blankimage-today").css("display", (inboxandDS[0].length + inboxandDS[1].length == 0) ? "flex" : "none")
-            $("#blankimage-today").animate({"opacity": "0.2"});
             Promise.all(
                 // load inbox tasks
                 inboxandDS[0].map(task => taskManager.generateTaskInterface("inbox", task)),
@@ -1461,11 +1455,8 @@ let ui = function() {
                     $("#unsorted-badge").html('' + inboxandDS[0].length);
                 }
                 if (inboxandDS[1].length === 0) {
-                    $("#ds-subhead").hide();
-                    $("#due-soon").hide();
+                    $("#duesoon-badge").html('0');
                 } else {
-                    $("#ds-subhead").show();
-                    $("#due-soon").show();
                     $("#duesoon-badge").html('' + inboxandDS[1].length);
                 }
             });
@@ -1608,10 +1599,27 @@ let ui = function() {
     $(document).on('click', '.upcoming-daterow-item', function(e) {
         $("#upcoming-daterow").children().each(function() {
             $(this).removeClass("upcoming-daterow-active");
+            $(this).addClass("upcoming-daterow-normal");
         });
         let original = $(this);
+        original.removeClass("upcoming-daterow-normal");
         original.addClass("upcoming-daterow-active");
-        pageIndex.dateSelected = original.attr("id").split("-")[2]
+        let cat = Number(original.attr("id").split("-")[2]);
+        pageIndex.dateSelected = cat;
+        let d = new Date();
+        //console.log(d, cat, d.getDate()+);
+        d.setDate(d.getDate()+cat);
+        //console.log(d);
+        if (cat == 0) {
+            $("#ds-text").html("Due Soon");
+            $("#duesoon-badge").show();
+            $("#ds-daterowfield").hide();
+        } else {
+            $("#ds-text").html("Due");
+            $("#duesoon-badge").hide();
+            $("#ds-daterowfield").css("display", "inline-block");
+            $("#duesoon-ondate").html(d.toLocaleDateString("en-US", { weekday: 'short', day: 'numeric'}));
+        }
         loadView("upcoming-page");
     });
 
@@ -1925,9 +1933,6 @@ let ui = function() {
                             tb.blur();
                             tb.val("");
                         });
-                
-
-                        $("#blankimage-today").css("display", "none");
                     });
                 });
             });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Condution",
-  "version": "0.1.3-beta.2",
+  "version": "0.2.0-beta.0",
   "description": "Tasks? Done. That was quick.",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
A much requested feature implimented perhaps a little weirdly.

Now you could timetravel on this niftly-little homepage date row to see upcoming tasks on any given date 7 days ahead, which, honestly, makes "upcoming" make more sense.

Just like this:

<img width="753" alt="Screen Shot 2020-06-25 at 2 41 33 PM" src="https://user-images.githubusercontent.com/28765741/85798794-fbbc8b80-b6f2-11ea-97a4-1557aecf4971.png">
